### PR TITLE
Allowing pause/resume if edges too slow to process

### DIFF
--- a/sshuttle/ssnet.py
+++ b/sshuttle/ssnet.py
@@ -41,7 +41,7 @@ CMD_UDP_OPEN = 0x420c
 CMD_UDP_DATA = 0x420d
 CMD_UDP_CLOSE = 0x420e
 CMD_PAUSE = 0x420f      # Use when client -> to edge too fast for edge to handle - pause reading
-CMD_RESUME = 0x4210     # Use when client -> to edge too fast for edge to handle - resume reading
+CMD_RESUME = 0x4210     # Use when client -> to edge buffer drains below threshold - resume reading
 
 cmd_to_name = {
     CMD_EXIT: 'EXIT',


### PR DESCRIPTION
See https://pythian.jira.com/browse/TEHAMA-10647?oldIssueView=true

Luc and I have been fine-tuning sshuttle to allow busy edges (e.g., workspace) to slow down communication between gateway and router.

Before:
1. In linux workspace in perf
2. run iperf3 to download a bunch of data
3. kill -STOP the iperf3 process, breaking the communication
4. BEFORE: at this point, iperf3 stops sending information to the workspace, but the sshuttle process on the router started increasing RAM until it ran out

This is the same symptom that we saw with a recent incident - we're not 100% sure exactly what the customer was doing (downloading what?) but they eventually couldn't use the network anymore and checking RAM showed that the router was out of RAM.  The workaround for that customer was to give them a bigger router with 8GB of RAM (since then, they haven't seen the issue, but I also don't think they've been doing the same use case because their RAM is < 2 GB).

4. AFTER: now, the iperf3 stops and sshuttle stops growing at 1 MB.  If we -CONT the iperf3 process, it starts up again.

The fix is similar to the concept of pause/resume (ping/pong) handshaking that was being done between router and gateway, but this time, focused on edge to router (for instance).

Some comments:

- Adding in 'constants' for some thresholds.  We're tracking how much data is on each channel's buffer, and a global how much data is on all buffers.  When the global count meets PAUSE_TRAFFIC_TO_EDGE_THRESHOLD and current buffer meets INDIVIDUAL_BUFFER_PAUSE_SIZE, we send a new CMD_PAUSE cmd on the current channel; we want to pause this channel's communication, and this channel only.
- If we're paused, we check if the current buffer's size falls below INDIVIDUAL_BUFFER_RESUME_SIZE and then send a CMD_RESUME channel.
- copy_to in parent SockWrapper now returns how many bytes written
- proxy handler only adds if the wrapper is not paused
- Child MuxWrapper has some new cleanup code in __del__ - if a communication channel completely breaks (found when we were breaking iperf3 runs), makes sure that the channel's current buffer is subtracted from the global count
- got_packet handles the new commands coming in
- got_packets, when working with CMD_TCP_DATA checks to see if maybe we need to pause
- The maybe_pause adds current data length to current buffer, then to the global count we're keeping.  Checks to see if we've reached the thresholds; if so, send the pause command.
- Child MuxWrapper overwrites parent's copy_to method.  Gets the number of bytes written by parent, then checks to see if we maybe need to resume.
- The maybe_resume substracts the bytes written from the global count.  Checks to see if we've dropped below the threshold and if so, sends the resume command.
- Split some lines to make them shorter.